### PR TITLE
"multiple runs" displaying implementation

### DIFF
--- a/pproc/DataSetList.R
+++ b/pproc/DataSetList.R
@@ -170,6 +170,13 @@ summary.DataSetList <- function(data) {
     as.data.frame
 }
 
+get_RT_runs.DataSetList <- function(dsList, ftarget, algorithm = 'all') {
+  if (algorithm != 'all')
+    dsList <- subset(dsList, algId == algorithm)
+  
+  lapply(dsList, function(ds) get_RT_runs(ds, ftarget)) %>% rbindlist
+}
+
 get_RT_summary.DataSetList <- function(dsList, ftarget, algorithm = 'all') {
   if (algorithm != 'all')
     dsList <- subset(dsList, algId == algorithm)
@@ -189,6 +196,13 @@ get_FV_summary.DataSetList <- function(dsList, runtime, algorithm = 'all') {
     dsList <- subset(dsList, algId == algorithm)
   
   lapply(dsList, function(ds) get_FV_summary(ds, runtime)) %>% rbindlist
+}
+
+get_FV_runs.DataSetList <- function(dsList, runtime, algorithm = 'all') {
+  if (algorithm != 'all')
+    dsList <- subset(dsList, algId == algorithm)
+  
+  lapply(dsList, function(ds) get_FV_runs(ds, runtime)) %>% rbindlist
 }
 
 get_FV_sample.DataSetList <- function(dsList, runtime, algorithm = 'all', ...) {

--- a/server.R
+++ b/server.R
@@ -488,6 +488,8 @@ shinyServer(function(input, output, session) {
     dt <- get_RT_summary(data, fseq)
     dt[, `:=`(upper = ERT + sd, lower = ERT - sd)]
     
+    dr <- get_RT_runs(data, fseq)
+    
     p <- plot_ly_default(x.title = "best-so-far f(x)-value", 
                          y.title = "function evaluations")
     
@@ -523,6 +525,16 @@ shinyServer(function(input, output, session) {
                          name = paste0(algId, '.median'), mode = 'lines+markers', 
                          marker = list(color = rgb_str),  
                          line = list(color = rgb_str, dash = 'dot'))
+      if (input$show.all){
+        dr_ERT <- dr[algId == attr(data[[i]], 'algId')]
+        for (run_v in colnames(dr_ERT))
+          if (and(run_v != 'algId', run_v != 'target')){
+            p %<>% add_trace(data = dr_ERT, x = ~target, y = dr_ERT[[run_v]], type = 'scatter', mode = 'lines',
+                             line = list(color = rgb_str, width = 0.5), 
+                             showlegend = F, name = paste(run_v,".", algId))
+          }
+        
+      }
     }
     p %<>%
       layout(xaxis = list(type = switch(input$semilogx, T = 'log', F = 'linear')),
@@ -1033,6 +1045,8 @@ shinyServer(function(input, output, session) {
     fce <- get_FV_summary(data, rt_seq)
     fce[, `:=`(upper = mean + sd, lower = mean - sd)]
     
+    fce_runs <- get_FV_runs(data, rt_seq)
+    
     p <- plot_ly_default(y.title = "best-so-far f(x)-value", x.title = "runtime")
     
     for (i in seq_along(data)) {
@@ -1064,6 +1078,16 @@ shinyServer(function(input, output, session) {
                          name = sprintf("%s.median", algId), mode = 'lines+markers', 
                          marker = list(color = rgb_str),
                          line = list(color = rgb_str, dash = 'dash'))
+      if (input$FCE_show.all){
+        fce_runs_ERT <- fce_runs[algId == attr(data[[i]], 'algId')]
+        for (run_v in colnames(fce_runs_ERT)){
+          if (and(run_v != 'algId', run_v != 'runtime')){
+            p %<>% add_trace(data = fce_runs_ERT, x = ~runtime, y = fce_runs_ERT[[run_v]], type = 'scatter', mode = 'lines',
+                             line = list(color = rgb_str, width = 0.3), 
+                             showlegend = F, name = paste(run_v, ".", algId))
+          }
+        }
+      }
     }
     p %<>%
       layout(xaxis = list(type = switch(input$FCE_semilogx, T = 'log', F = 'linear')),

--- a/ui.R
+++ b/ui.R
@@ -283,17 +283,36 @@ body <- dashboardBody(
                                            label = 'show/hide median',
                                            value = F),
                              
-                             checkboxInput('show.all',
-                                           label = 'show/hide multiple runs',
-                                           value = F),
-                             
                              checkboxInput('semilogx', 
                                            label = 'scale x axis log10',
                                            value = T),
                              
                              checkboxInput('semilogy', 
                                            label = 'scale y axis log10',
-                                           value = T)
+                                           value = T),
+                             
+                             checkboxInput('show_all',
+                                           label = 'show/hide multiple runs',
+                                           value = F),
+                             conditionalPanel(condition = "input.show_all == true",
+                                              
+                                              fluidRow(column(
+                                                11,
+                                                offset = 1,
+                                                sliderInput('show.density',
+                                                            label = "Runs density(%)",
+                                                            min = 1, max = 100, value = 50, step = 1),
+                                                checkboxInput('show.best_of_all',
+                                                              label = 'show/hide best run',
+                                                              value = F),
+                                                checkboxInput('show.pareto_optima',
+                                                              label = 'show/hide pareto optimal front',
+                                                              value = F)
+                                              )))
+                             
+                             
+                                              
+                                              
                              
                              # checkboxInput('show.instance', 
                              #               label = 'show each independent run',

--- a/ui.R
+++ b/ui.R
@@ -683,17 +683,32 @@ appear when hovering over the figure. A csv file with the runtime data can be do
                                              label = 'show/hide median',
                                              value = F),
                                
-                               checkboxInput('FCE_show.all',
-                                             label = 'show/hide multiple runs',
-                                             value = F),
-                               
                                checkboxInput('FCE_semilogx', 
                                              label = 'scale x axis log10',
                                              value = T),
                                
                                checkboxInput('FCE_semilogy', 
                                              label = 'scale y axis log10',
-                                             value = T)
+                                             value = T),
+                               
+                               checkboxInput('FCE_show_all',
+                                             label = 'show/hide multiple runs',
+                                             value = F),
+                               conditionalPanel(condition = "input.FCE_show_all == true",
+                                                
+                                                fluidRow(column(
+                                                  11,
+                                                  offset = 1,
+                                                  sliderInput('FCE_show.density',
+                                                              label = "Runs density(%)",
+                                                              min = 1, max = 100, value = 50, step = 1),
+                                                  checkboxInput('FCE_show.best_of_all',
+                                                                label = 'show/hide best run',
+                                                                value = F),
+                                                  checkboxInput('FCE_show.pareto_optima',
+                                                                label = 'show/hide pareto optimal front',
+                                                                value = F)
+                                                )))
                              )
                          ),
                          

--- a/ui.R
+++ b/ui.R
@@ -283,6 +283,10 @@ body <- dashboardBody(
                                            label = 'show/hide median',
                                            value = F),
                              
+                             checkboxInput('show.all',
+                                           label = 'show/hide multiple runs',
+                                           value = F),
+                             
                              checkboxInput('semilogx', 
                                            label = 'scale x axis log10',
                                            value = T),
@@ -658,6 +662,10 @@ appear when hovering over the figure. A csv file with the runtime data can be do
                                
                                checkboxInput('FCE_show.median', 
                                              label = 'show/hide median',
+                                             value = F),
+                               
+                               checkboxInput('FCE_show.all',
+                                             label = 'show/hide multiple runs',
                                              value = F),
                                
                                checkboxInput('FCE_semilogx', 


### PR DESCRIPTION
Multiple runs displaying implemented 
In «Fixed-Target/Budget Results» menu checkbox «show/hide multiple runs» was added. If checkbox is active then plotly will draw all runs from data uploaded.  This allows user to see every run's trace on the graph, observing and comparing them.
![example1](https://user-images.githubusercontent.com/18073946/50253588-b7647700-03fb-11e9-995d-3b1d5da711c7.png)

There is a problem with interaction with traces -  if user hovers a mouse cursor over plot, then plotly, by default, signs names and values over all traces that exists. As a result, while plotly shows small amount of data it instantly signs all lines; but with the big data pool the plot cannot show all the values and starts freezing. Moreover there isn't enough space on page for values to be shown  ![problem1](https://user-images.githubusercontent.com/18073946/50252692-ce559a00-03f8-11e9-9cba-e6e8d9c8e6c1.png) 
![problem2](https://user-images.githubusercontent.com/18073946/50252859-6e132800-03f9-11e9-9581-3634086d1d03.png)
Here is the pictures, where 100 different traces were drawn, but only half of their values were able to fit on the page.
Maybe, in this case it will be better toggling off «compare data on hover» feature of plotly, when showing all run's traces from data.